### PR TITLE
match envoy circuit breaker defaults

### DIFF
--- a/gm/intermediates.cue
+++ b/gm/intermediates.cue
@@ -568,11 +568,11 @@ import (
 // Setting _enable_circuit_breakers: true on the #cluster will use these values
 // unless overriden.
 #circuit_breakers_default: {
-	max_connections:      int64 | *512
-	max_pending_requests: int64 | *512
-	max_requests:         int64 | *512
-	max_retries:          int64 | *2
-	max_connection_pools: int64 | *512
+	max_connections:      int64 | *1024
+	max_pending_requests: int64 | *1024
+	max_requests:         int64 | *1024
+	max_retries:          int64 | *3
+	max_connection_pools: int64 | *1024
 	track_remaining:      bool | *false
 }
 


### PR DESCRIPTION
Our default circuit breaker configs now matches [Envoy's defaults](https://www.envoyproxy.io/docs/envoy/v1.16.5/api-v3/config/cluster/v3/circuit_breaker.proto.html#config-cluster-v3-circuitbreakers-thresholds). I removed max_connection_pools because, if undefined, Envoy will set this to unlimited, thus I removed it. We can document it existence in gm-docs and explain when to use it.