### PR TITLE
add domain toggle for require_client_certs

### DIFF
--- a/gm/intermediates.cue
+++ b/gm/intermediates.cue
@@ -28,6 +28,11 @@ import (
 	// Set _force_https to true to turn on secure traffic to the service.
 	// For edge services that want TLS, this should be enabled
 	_force_https: bool | *false
+	// Set _require_client_certs for TLS enabled sidecars to require
+	// x.509 client certificates during the TLS handshake. For web browsers,
+	// the user will need to load their certificate into their browser or
+	// computer's certificate storage.
+	_require_client_certs: bool | *false
 	// Identifers for the domain object within the mesh
 	domain_key: string
 	name:       string | *"*"
@@ -59,6 +64,7 @@ import (
 					key_path:         _key_path
 				},
 			]
+			require_client_certs: _require_client_certs
 		}
 	}
 }


### PR DESCRIPTION
During my testing of PKI + RBAC I came across the lack of a configuration in the domain ssl_config for require client certs on the TLS handshake. 