### PR TITLE
add elasticsearch-password secret

### DIFF
--- a/inputs.cue
+++ b/inputs.cue
@@ -103,7 +103,8 @@ defaults: {
 		// to create more or less indexes depending on your storage and performance requirements.
 		index: "gm-audits-%Y-%m"
 		// elasticsearch_host can be an IP address or DNS hostname to your Elasticsearch instance.
-		elasticsearch_host: ""
+		// It's set to a non-empty value so that the audit-pipeline starts successfully.
+		elasticsearch_host: "localhost"
 		// elasticsearch_port is the port of your Elasticsearch instance.
 		elasticsearch_port: 443
 		// mounted_certs determines whether the observables application uses certificates
@@ -113,6 +114,8 @@ defaults: {
 		// of your Elasticsearch instance. This is used by to sync audit data
 		// with Elasticsearch.
 		elasticsearch_endpoint: "https://\(elasticsearch_host):\(elasticsearch_port)"
+		// Default Elasticsearch password secret name.
+		elasticsearch_password_secret: "elasticsearch-password"
 	}
 
 	edge: {

--- a/k8s/outputs/EXTRACTME.cue
+++ b/k8s/outputs/EXTRACTME.cue
@@ -16,42 +16,43 @@ if defaults.jwtsecurity != _|_ {
 jwt_security_manifests: jwt_security
 // Spire-related manifests
 spire_manifests: list.Concat([
-	spire_namespace,
-	spire_server,
-	spire_agent,
+			spire_namespace,
+			spire_server,
+			spire_agent,
 ])
 // Deploys the operator and optionally spire (so these manifests are in place before anything else)
 operator_manifests: list.Concat([
-	operator_namespace,
-	operator_sts,
-	operator_k8s,
-	[ for x in openshift_privileged_scc if config.openshift {x}],
-	[ for x in openshift_vector_scc if config.openshift && config.enable_audits {x}],
-	[ for x in openshift_spire_scc if config.openshift && config.spire {x}],
-	[ for x in spire_manifests if config.deploy_spire {x}],
-	[ for x in vector_permissions if config.enable_audits {x}],
+			operator_namespace,
+			operator_sts,
+			operator_k8s,
+			[ for x in openshift_privileged_scc if config.openshift {x}],
+			[ for x in openshift_vector_scc if config.openshift && config.enable_audits {x}],
+			[ for x in openshift_spire_scc if config.openshift && config.spire {x}],
+			[ for x in spire_manifests if config.deploy_spire {x}],
+			[ for x in vector_permissions if config.enable_audits {x}],
 ])
 // For development convenience, not otherwise used
 all_but_operator_manifests: list.Concat([
-	operator_namespace,
-	operator_k8s,
-	[ for x in spire_manifests if config.spire {x}],
+				operator_namespace,
+				operator_k8s,
+				[ for x in spire_manifests if config.spire {x}],
 ])
 
 // Deployed by the operator when you ask for a Mesh
 k8s_manifests: list.Concat([
-  controlensemble,
-	catalog,
-	redis,
-	edge,
-	dashboard,
-	[ for x in prometheus if config.enable_historical_metrics && len(defaults.prometheus.external_host) == 0 {x}],
-	[ for x in prometheus_proxy if config.enable_historical_metrics && len(defaults.prometheus.external_host) > 0 {x}],
-	[ for x in openshift_vector_scc_bindings if config.openshift && config.enable_audits {x}],
-	[ for x in openshift_spire if config.openshift && config.spire {x}],
-	[ for x in observables if config.enable_audits {x}],
-	[ for x in vector if config.enable_audits {x}],
-	[ for x in jwt_security_manifests if _enable_jwtsecurity {x}],
+		controlensemble,
+		catalog,
+		redis,
+		edge,
+		dashboard,
+		[ for x in prometheus if config.enable_historical_metrics && len(defaults.prometheus.external_host) == 0 {x}],
+		[ for x in prometheus_proxy if config.enable_historical_metrics && len(defaults.prometheus.external_host) > 0 {x}],
+		[ for x in openshift_vector_scc_bindings if config.openshift && config.enable_audits {x}],
+		[ for x in openshift_spire if config.openshift && config.spire {x}],
+		[ for x in observables if config.enable_audits {x}],
+		[ for x in vector if config.enable_audits {x}],
+		[ for x in elasticsearch_password if config.enable_audits {x}],
+		[ for x in jwt_security_manifests if _enable_jwtsecurity {x}],
 ])
 
 vector_manifests_yaml:      yaml.MarshalStream(vector)

--- a/k8s/outputs/elasticsearch_password.cue
+++ b/k8s/outputs/elasticsearch_password.cue
@@ -1,0 +1,27 @@
+// Elasticsearch password secret for Audit App/Pipeline.
+// This secret is created at install-time of the mesh to ensure that
+// the Audit App/Pipeline pods start successfully. The password is
+// intentionally fake and needs to be changed after the mesh is installed.
+
+package greymatter
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+let Name = defaults.audits.elasticsearch_password_secret
+
+elasticsearch_password: [
+	corev1.#Secret & {
+		apiVersion: "v1"
+		kind:       "Secret"
+		type:       "Opaque"
+		metadata: {
+			name:      Name
+			namespace: mesh.spec.install_namespace
+		}
+		stringData: {
+			password: "CHANGE_ME"
+		}
+	},
+]

--- a/k8s/outputs/observables.cue
+++ b/k8s/outputs/observables.cue
@@ -56,7 +56,7 @@ observables: [
 								name: "ES_PASSWORD"
 								valueFrom: {
 									secretKeyRef: {
-										name: "elasticsearch-password"
+										name: defaults.audits.elasticsearch_password_secret
 										key:  "password"
 									}
 								}

--- a/k8s/outputs/vector.cue
+++ b/k8s/outputs/vector.cue
@@ -142,8 +142,8 @@ vector: [
 							name: "ELASTICSEARCH_PASSWORD"
 							valueFrom: {
 								secretKeyRef: {
+									name: defaults.audits.elasticsearch_password_secret
 									key:  "password"
-									name: "elasticsearch-password"
 								}
 							}
 						}]


### PR DESCRIPTION
This PR adds a Secret containing a fake password for Elasticsearch. This allows the audit app/pipeline pods to start at install-time of the mesh. The other necessary change was to provide a non-empty string for the Elasticsearch host. Without this the audit pipeline wouldn't start. These changes ensure that all pods start successfully when the the mesh is installed. I'll update this page https://docs.greymatter.io/getting-started/installation/#prepare-audit-pipeline to coincide with these changes. 

Run `cue eval -c ./k8s/outputs --out text -e k8s_manifests_yaml` and ensure that the K8s configs look correct. I deployed this to http://52.158.165.57:10808 and confirmed the changes worked.