### PR TITLE
update egress cluster to elasticsearch to always use tls

### DIFF
--- a/gm/outputs/observables.cue
+++ b/gm/outputs/observables.cue
@@ -56,7 +56,7 @@ observables_config: [
 	#cluster & {
 		cluster_key:    EgressToElasticSearchName
 		name:           "elasticsearch"
-		_force_https:   defaults.audits.mounted_certs
+		require_tls:    true
 		_upstream_host: defaults.audits.elasticsearch_host
 		_upstream_port: defaults.audits.elasticsearch_port
 	},

--- a/inputs.cue
+++ b/inputs.cue
@@ -107,9 +107,6 @@ defaults: {
 		elasticsearch_host: "localhost"
 		// elasticsearch_port is the port of your Elasticsearch instance.
 		elasticsearch_port: 443
-		// mounted_certs determines whether the observables application uses certificates
-		// mounted at /etc/proxy/tls/sidecar in the observables application's sidecar. 
-		mounted_certs: bool | *false
 		// elasticsearch_endpoint is the full endpoint containing protocol, host, and port
 		// of your Elasticsearch instance. This is used by to sync audit data
 		// with Elasticsearch.


### PR DESCRIPTION
I've reverted the addition that checks for mounted_certs boolean. We always want to connect to Elasticsearch using TLS. Whether we're using one-way or two-way TLS.