### PR TITLE
fix(catalog): [sc-30759] greymatter catalog entry not displaying usage and uptime summaries

### DIFF
--- a/gm/outputs/observables.cue
+++ b/gm/outputs/observables.cue
@@ -127,7 +127,7 @@ observables_config: [
 		api_endpoint:              "/services/audits"
 		business_impact:           "critical"
 		enable_instance_metrics:   true
-		enable_historical_metrics: false
+		enable_historical_metrics: config.enable_historical_metrics
 		capability:                "Mesh"
 	},
 ]


### PR DESCRIPTION
Story details: https://app.shortcut.com/grey-matter/story/30759

This PR adds the toggle for `enable_historical_metrics` like the other core mesh services.