### PR TITLE
change the order of operator manifest.yaml generated by cue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Changed the order that operator resources are created
 - Remove "plus" from default watched namespaces
 
 ## 0.13.1 (November 9th, 2022)

--- a/k8s/outputs/EXTRACTME.cue
+++ b/k8s/outputs/EXTRACTME.cue
@@ -23,8 +23,8 @@ spire_manifests: list.Concat([
 // Deploys the operator and optionally spire (so these manifests are in place before anything else)
 operator_manifests: list.Concat([
 			operator_namespace,
-			operator_sts,
 			operator_k8s,
+			operator_sts,
 			[ for x in openshift_privileged_scc if config.openshift {x}],
 			[ for x in openshift_vector_scc if config.openshift && config.enable_audits {x}],
 			[ for x in openshift_spire_scc if config.openshift && config.spire {x}],


### PR DESCRIPTION
[sc-29390]

to generate the manifest run: `cue eval -c ./k8s/outputs -e operator_manifests_yaml --out=text > operator.yaml`

> note: in `operator.yaml` you'll see that the gm-webhook-cert secret is now higher in the yaml than before.  It just needs to be above the operator stateful set.

<img width="806" alt="image" src="https://user-images.githubusercontent.com/21246992/201751594-c62437c8-a21c-4fff-ac85-3c7b7c8b3f3c.png">
