### PR TITLE
add more robust remote JWKS configs

### DIFF
--- a/gm/intermediates.cue
+++ b/gm/intermediates.cue
@@ -455,8 +455,11 @@ import (
 					providers: defaults.edge.oidc.jwt_authn_provider
 					providers: keycloak: issuer: _oidc_provider
 
-					if defaults.edge.oidc.jwt_authn_provider.keycloak.remote_jwks != _|_ {
-						providers: keycloak: remote_jwks: http_uri: uri: *"\(_oidc_provider)/protocol/openid-connect/certs" | string
+					if defaults.edge.oidc.enable_remote_jwks {
+						providers: keycloak: remote_jwks: http_uri: {
+							cluster: defaults.edge.oidc.remote_jwks_cluster
+							uri:     *"\(_oidc_provider)/protocol/openid-connect/certs" | string
+						}
 					}
 				}
 			}

--- a/gm/outputs/EXTRACTME.cue
+++ b/gm/outputs/EXTRACTME.cue
@@ -14,15 +14,16 @@ if defaults.jwtsecurity != _|_ {
 }
 
 mesh_configs: list.Concat([
-	redis_config,
-	edge_config,
-	catalog_config,
-	controlensemble_config,
-	dashboard_config,
-	catalog_entries,
-	[ for x in prometheus_config if config.enable_historical_metrics {x}],
-	[ for x in jwtsecurity_config if _enable_jwtsecurity {x}],
-	[ for x in observables_config if config.enable_audits {x}],
+		[ for x in remote_jwks_config if defaults.edge.oidc.enable_remote_jwks {x}],
+		redis_config,
+		edge_config,
+		catalog_config,
+		controlensemble_config,
+		dashboard_config,
+		catalog_entries,
+		[ for x in prometheus_config if config.enable_historical_metrics {x}],
+		[ for x in jwtsecurity_config if _enable_jwtsecurity {x}],
+		[ for x in observables_config if config.enable_audits {x}],
 ])
 
 redis_listener: redis_listener_object // special because we need to re-apply it when Spire is enabled for every new sidecar

--- a/gm/outputs/edge.cue
+++ b/gm/outputs/edge.cue
@@ -2,19 +2,25 @@
 
 package greymatter
 
-let EgressToRedisName = "\(defaults.edge.key)_egress_to_redis"
+import (
+	"list"
+)
 
-// Uncomment the below line for use with a remote JWKS provider (in this case, Keycloak)
-// let EdgeToKeycloakName = defaults.edge.oidc.jwt_authn_provider.keycloak.remote_jwks.http_uri.cluster
+let egress_to_redis = "\(defaults.edge.key)_egress_to_redis"
+
+let upstream_clusters = list.Concat([
+	[defaults.edge.key, egress_to_redis],
+	[ if defaults.edge.oidc.enable_remote_jwks {defaults.edge.oidc.remote_jwks_cluster}],
+])
 
 edge_config: [
 	// This domain is special because it uses edge certs instead of sidecar certs.  This secures outside -> in traffic
 	#domain & {
-		domain_key:   defaults.edge.key
-		_force_https: defaults.edge.enable_tls
-		_trust_file: "/etc/proxy/tls/edge/ca.crt"
+		domain_key:        defaults.edge.key
+		_force_https:      defaults.edge.enable_tls
+		_trust_file:       "/etc/proxy/tls/edge/ca.crt"
 		_certificate_path: "/etc/proxy/tls/edge/server.crt"
-		_key_path: "/etc/proxy/tls/edge/server.key"
+		_key_path:         "/etc/proxy/tls/edge/server.key"
 	},
 	#listener & {
 		listener_key:                defaults.edge.key
@@ -25,10 +31,10 @@ edge_config: [
 		_enable_fault_injection:     false
 		_enable_ext_authz:           false
 		_oidc_endpoint:              defaults.edge.oidc.endpoint
-		_oidc_service_url:           "https://\(defaults.edge.oidc.domain):\(defaults.ports.edge_ingress)"
+		_oidc_service_url:           "https://\(defaults.edge.oidc.edge_domain):\(defaults.ports.edge_ingress)"
 		_oidc_client_id:             defaults.edge.oidc.client_id
 		_oidc_client_secret:         defaults.edge.oidc.client_secret
-		_oidc_cookie_domain:         defaults.edge.oidc.domain
+		_oidc_cookie_domain:         defaults.edge.oidc.edge_domain
 		_oidc_realm:                 defaults.edge.oidc.realm
 	},
 	// This cluster must exist (though it never receives traffic)
@@ -39,18 +45,18 @@ edge_config: [
 
 	// egress -> redis
 	#domain & {
-		domain_key: EgressToRedisName
-		port: defaults.ports.redis_ingress
+		domain_key: egress_to_redis
+		port:       defaults.ports.redis_ingress
 	},
 	#cluster & {
-		cluster_key:  EgressToRedisName
+		cluster_key:  egress_to_redis
 		name:         defaults.redis_cluster_name
 		_spire_self:  defaults.edge.key
 		_spire_other: defaults.redis_cluster_name
 	},
-	#route & {route_key: EgressToRedisName},
+	#route & {route_key: egress_to_redis},
 	#listener & {
-		listener_key: EgressToRedisName
+		listener_key: egress_to_redis
 		// egress listeners are local-only
 		ip:            "127.0.0.1"
 		port:          defaults.ports.redis_ingress
@@ -58,28 +64,8 @@ edge_config: [
 	},
 
 	#proxy & {
-		proxy_key: defaults.edge.key
-		domain_keys: [defaults.edge.key, EgressToRedisName]
-		listener_keys: [defaults.edge.key, EgressToRedisName]
-	}
-
-	// egress -> Keycloak for OIDC/JWT Authentication (only necessary with remote JWKS provider)
-	// NB: You need to add the EdgeToKeycloakName key to the domain_keys and listener_keys 
-	// in the #proxy above for the cluster to be discoverable by Envoy
-	// #cluster & {
-	//  cluster_key:    EdgeToKeycloakName
-	//  _upstream_host: defaults.edge.oidc.endpoint_host
-	//  _upstream_port: defaults.edge.oidc.endpoint_port
-	//  ssl_config: {
-	//   protocols: ["TLSv1_2"]
-	//   sni: defaults.edge.oidc.endpoint_host
-	//  }
-	//  require_tls: true
-	// },
-	// #route & {route_key:   EdgeToKeycloakName},
-	// #domain & {domain_key: EdgeToKeycloakName, port: defaults.edge.oidc.endpoint_port},
-	// #listener & {
-	//  listener_key: EdgeToKeycloakName
-	//  port:         defaults.edge.oidc.endpoint_port
-	// },
+		proxy_key:     defaults.edge.key
+		domain_keys:   upstream_clusters
+		listener_keys: upstream_clusters
+	},
 ]

--- a/gm/outputs/remote_jwks.cue
+++ b/gm/outputs/remote_jwks.cue
@@ -1,0 +1,26 @@
+package greymatter
+
+let EdgeToKeycloakName = defaults.edge.oidc.remote_jwks_cluster
+
+remote_jwks_config: [
+	#domain & {
+		domain_key: EdgeToKeycloakName
+		port:       defaults.edge.oidc.egress_port
+	},
+	#cluster & {
+		cluster_key:    EdgeToKeycloakName
+		_upstream_host: defaults.edge.oidc.upstream_host
+		_upstream_port: defaults.edge.oidc.upstream_port
+		ssl_config: {
+			protocols: [ "TLS_AUTO"]
+			sni:        defaults.edge.oidc.upstream_host
+			trust_file: ""
+		}
+		require_tls: true
+	},
+	#route & {route_key: EdgeToKeycloakName},
+	#listener & {
+		listener_key: EdgeToKeycloakName
+		port:         defaults.edge.oidc.egress_port
+	},
+]

--- a/inputs.cue
+++ b/inputs.cue
@@ -125,28 +125,50 @@ defaults: {
 		enable_tls:  false
 		secret_name: "gm-edge-ingress-certs"
 		oidc: {
-			endpoint_host: ""
-			endpoint_port: 0
-			endpoint:      "https://\(endpoint_host):\(endpoint_port)"
-			domain:        ""
-			client_id:     "\(defaults.edge.key)"
+			// upstream_host is the FQDN of your OIDC service.
+			upstream_host: "foobar.oidc.com"
+			// upstream_port is the port your OIDC service is listening on.
+			upstream_port: 443
+			// egress_port is the port used by the edge proxy to make egress
+			// connections to your upstream OIDC service.
+			egress_port: 8443
+			// endpoint is the protocol, host, and port of your OIDC service.
+			// If the upstream_port is 443, it's unnecessary to provide it. If
+			// the upstream_port is not 443, you must provide it with: "https://\(upstream_host):\(upstream_port)".
+			endpoint: "https://\(upstream_host)"
+			// edge_domain is the FQDN of your edge service. It's used by
+			// greymatter's OIDC filters, and will be used to redirect the user
+			// back to the mesh, upon successful authentication.
+			edge_domain: "foobar.com"
+			// realm is the ID of a realm in your OIDC provider.
+			realm: "greymatter"
+			// client_id is the ID of a client in a realm in your OIDC provider.
+			client_id: "greymatter"
+			// client_secret is the secret key of a client in a realm in your
+			// OIDC provider. 
 			client_secret: ""
-			realm:         ""
+			// enable_remote_jwks is a toggle that automatically enables remote
+			// JSON Web Key Sets (JWKS) verification with your OIDC provider.
+			// Alternatively, you can disable this and use local_jwks below.
+			// It's advised to enable remote JWKS because it is reslient to 
+			// key rotation.
+			enable_remote_jwks: false
+			// remote_jwks_cluster is the name of the egress cluster used by
+			// the edge proxy to make connections to your OIDC service.
+			remote_jwks_cluster: "edge_egress_to_oidc"
+			// jwt_authn_provider contains configuration for JWT authentication.
+			// This is used in conjunction with remote JWKS or local JWKS.
 			jwt_authn_provider: {
 				keycloak: {
-					audiences: ["\(defaults.edge.key)"]
-					local_jwks: {
-						inline_string: #"""
-					  {}
-					  """#
-					}
-					// If you want to use a remote JWKS provider, comment out local_jwks above, and
-					// uncomment the below remote_jwks configuration. There are coinciding configurations
-					// in ./gm/outputs/edge.cue that you will also need to uncomment.
-					// remote_jwks: {
-					//  http_uri: {
-					//   cluster: "edge_to_keycloak" // this key should be unique across the mesh
-					//  }
+					audiences: ["greymatter"]
+					// If using local JWKS verification, disable enable_remote_jwks above and
+					// uncomment local_jwks below. You will need to paste the JWKS JSON
+					// from your OIDC provider inside the inline_string's starting and ending
+					// triple quotes.
+					// local_jwks: {
+					//  inline_string: #"""
+					//   {}
+					//   """#
 					// }
 				}
 			}


### PR DESCRIPTION
This PR ensures that enabling remote JWKS doesn't fail, as long as the proper values are set in inputs.cue.

Issues that were fixed:

1. The order in which mesh configs were applied. The egress to Keycloak config route would not always get created, causing a cascading effect that culminated in the edge proxy never seeing the edge-to-keycloak cluster.
2. Applying mTLS on the upstream cluster to Keycloak. The certs applied to the egress cluster did not match the upstream service's certs.

Improvements:

1. The previous implementation had users uncommenting configs in inputs.cue and edge.cue for remote JWKS. I've moved the mesh configs for egress to Keycloak to a separate CUE file that gets conditionally applied via a new boolean in inputs.cue `defaults.edge.oidc.enable_remote_jwks`. When `true`, this will also conditionally apply the appropriate listener and domain keys to edge's proxy. This is far easier than uncommenting CUE configs and is more like a toggle now.
2. There are now copious amounts of comments in inputs.cue for OIDC configs. This should help some other issues folks were running into when attempting to set up meshes with https://iam2.greymatter.io.
3. I'm now catering the OIDC configs for an externally hosted provider because that is likely to be the common deployment scenario of our customers.

Testing:

I need someone to deploy a mesh end-to-end with TLS and OIDC using https://iam2.greymatter.io.
 