### PR TITLE
gives the operator the ability to delete deployments, statefulsets, c…

### DIFF
--- a/k8s/outputs/operator.cue
+++ b/k8s/outputs/operator.cue
@@ -288,6 +288,7 @@ operator_k8s: [
 				"list",
 				"create",
 				"update",
+				"delete",
 			]
 		}, {
 			apiGroups: [
@@ -315,6 +316,7 @@ operator_k8s: [
 				"create",
 				"update",
 				"patch",
+				"delete",
 			]
 		}, {
 			apiGroups: [


### PR DESCRIPTION
The operator currently does not have the ability to delete and delete resources.  

Lets say you introduce another edge `services-edge` then you update cue to toggle that additional edge off.  Currently the mesh configs are removed however the k8s resources are not removed.

This PR takes care of that.