### PR TITLE
Automate release

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -58,7 +58,8 @@ steps:
       
       - buildkite-agent artifact upload "generated-manifests/*"
 
-  - label: "Release"
+  - label: "Create Tarball and push to staging"
+    key: "push-to-staging"
     depends_on:
       - test
       - generate-manifests
@@ -67,3 +68,35 @@ steps:
       - cp ./generated-manifests/operator.yaml ./operator.yaml
       - cp ./generated-manifests/operator-spire.yaml ./operator_withspire.yaml
       - ./scripts/cibuild release
+
+  - label: "test-promote artifacts to staging"
+    key: "promote-test"
+    env:
+      SRC_GENERIC_CI: "dev-generic"
+      DEST_GENERIC_CI: "ci-staging-generic"
+      SRC_OCI_CI: "release-oci"
+      DEST_OCI_CI: "ci-staging-oci"
+    # promotion defaults to dry run
+    command: ./scripts/promotion 
+
+
+  # promotes artifacts to their release repos
+  # updates greymatter-download-<version><-rc>.sh file
+  
+  - label: "promote artifacts to staging"
+    key: "promote"
+    if: | 
+      build.pull_request.base_branch == "main"
+    depends_on: 
+      - promote-test
+    env:
+      SRC_GENERIC_CI: "dev-generic"
+      DEST_GENERIC_CI: "ci-staging-generic"
+      SRC_OCI_CI: "release-oci"
+      DEST_OCI_CI: "ci-staging-oci"
+    # --yes flag for promotion results in actual promotion
+    command: ./scripts/promotion --yes
+    artifact_paths:
+      - release-versions.yaml
+      - greymatter-download*.sh
+      - inputs-output.cue

--- a/.buildkite/tag.yaml
+++ b/.buildkite/tag.yaml
@@ -1,0 +1,40 @@
+steps:
+  - label: "validate changelog has been updated"
+    key: "validate-changelog-tag"
+    if: build.message !~ /skip changelog validation/
+    commands:
+      - echo "STUB for validate changelog diff between last tag and this tag"
+      - git diff --name-only ${BUILDKITE_TAG} $(git tag --sort=-creatordate | grep -A 1 ${BUILDKITE_TAG} | tail -n 1) | grep CHANGELOG.md > diff.txt
+      - if [[ $(awk 'END {print NR}' diff.txt) -ne 1 ]]; then exit 9; fi
+
+  # this is in place of automated smoke test
+  - block: "I have run a smoke test on generated inputs-staging.cue"
+
+  - label: "test-promote artifacts to oci/ generic"
+    key: "promote-test-tag"
+    env:
+      SRC_GENERIC_CI: "ci-staging-generic"
+      DEST_GENERIC_CI: "generic"
+      SRC_OCI_CI: "ci-staging-oci"
+      DEST_OCI_CI: "oci"
+    # promotion defaults to dry run
+    command: ./scripts/promotion 
+
+  # promotes artifacts to their release repos
+  # TODO: validates updates greymatter-download-<version><-rc>.sh file
+  - label: "promote artifacts to oci/ generic"
+    key: "promote-tag"
+    depends_on: 
+      - promote-test-tag
+    env:
+      SRC_GENERIC_CI: "ci-staging-generic"
+      DEST_GENERIC_CI: "generic"
+      SRC_OCI_CI: "ci-staging-oci"
+      DEST_OCI_CI: "oci"
+    # --yes flag for promotion results in actual promotion
+    command: ./scripts/promotion --yes
+    # eventually we will want to automatically push greymatter-download*.sh to artifactory
+    artifact_paths:
+      - release-versions.yaml
+      - greymatter-download*.sh
+      - inputs-output.cue

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/greymatter-download*.sh
+release-versions.yaml

--- a/inputs.cue
+++ b/inputs.cue
@@ -40,11 +40,11 @@ mesh: meshv1.#Mesh & {
 		install_namespace: string | *"greymatter"
 		watch_namespaces:  [...string] | *["default", "examples"]
 		images: {
-			proxy:       string | *"greymatter.jfrog.io/oci/greymatter-proxy:1.8.0-ubi8.6-2022-11-22"
-			catalog:     string | *"greymatter.jfrog.io/oci/greymatter-catalog:3.0.8-ubi8.6-2022-11-09"
-			dashboard:   string | *"greymatter.jfrog.io/oci/greymatter-dashboard:6.0.5-ubi8.6-2022-11-22"
-			control:     string | *"greymatter.jfrog.io/oci/greymatter-control:1.8.2-ubi8.6-2022-11-22"
-			control_api: string | *"greymatter.jfrog.io/oci/greymatter-control-api:1.8.2-ubi8.6-2022-11-22"
+			proxy:       string | *"greymatter.jfrog.io/release-oci/greymatter-proxy:1.8.0-ubi8.6-2022-11-22"
+			catalog:     string | *"greymatter.jfrog.io/release-oci/greymatter-catalog:3.0.8-ubi8.6-2022-11-09"
+			dashboard:   string | *"greymatter.jfrog.io/release-oci/greymatter-dashboard:6.0.5-ubi8.6-2022-11-22"
+			control:     string | *"greymatter.jfrog.io/release-oci/greymatter-control:1.8.2-ubi8.6-2022-11-22"
+			control_api: string | *"greymatter.jfrog.io/release-oci/greymatter-control-api:1.8.2-ubi8.6-2022-11-22"
 			redis:       string | *"index.docker.io/library/redis:6.2.7"
 			prometheus:  string | *"index.docker.io/prom/prometheus:v2.40.1"
 		}
@@ -76,9 +76,10 @@ defaults: {
 	}
 
 	images: {
-		operator:          string | *"greymatter.jfrog.io/oci/greymatter-operator:0.13.0-ubi8.6-2022-11-09" @tag(operator_image)
+		cli:               string | *"greymatter.jfrog.io/release-oci/greymatter-cli:4.5.2-ubi8.6-2022-11-22"
+		operator:          string | *"greymatter.jfrog.io/release-oci/greymatter-operator:0.13.0-ubi8.6-2022-11-09" @tag(operator_image)
 		vector:            string | *"timberio/vector:0.22.0-debian"
-		observables:       string | *"greymatter.jfrog.io/oci/greymatter-audits:1.1.4-ubi8.6-2022-11-09"
+		observables:       string | *"greymatter.jfrog.io/release-oci/greymatter-audits:1.1.4-ubi8.6-2022-11-09"
 		keycloak:          string | *"quay.io/keycloak/keycloak:19.0.3"
 		keycloak_postgres: string | *"postgres:15.0"
 	}

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -7,9 +7,6 @@ release_bundle() {
   if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
     bundle_and_push "latest"
   fi
-  if [[ -n "$BUILDKITE_TAG" ]]; then
-    bundle_and_push ${BUILDKITE_TAG:1}
-  fi
 }
 
 # Convenience function to push tarball to Artifactory
@@ -28,6 +25,8 @@ bundle_and_push() {
     --exclude="scripts/cibuild" \
     --exclude="scripts/bootstrap" \
     --exclude="scripts/update" \
+    --exclude="scripts/promotion" \
+    --exclude="greymatter-download-template.sh" \
     -cvzf "$workspace/$tarball" .
 
   cd $workspace
@@ -39,7 +38,7 @@ bundle_and_push() {
 
   # Artifactory upload
   buildkite-agent artifact upload "$tarball" "rt://dev-generic/greymatter-core"
-  
+
   # Cleanup the tarball
   rm $tarball
 }

--- a/scripts/greymatter-download-template.sh
+++ b/scripts/greymatter-download-template.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+artifacts=(
+        "https://greymatter.jfrog.io/artifactory/generic/greymatter-cli/greymatter-cli_<VERSION>-fips_linux_amd64.tar.gz"
+        "https://greymatter.jfrog.io/artifactory/generic/greymatter-catalog/greymatter-catalog_<VERSION>_linux_amd64.tar.gz"
+        "https://greymatter.jfrog.io/artifactory/generic/greymatter-control/greymatter-control_<VERSION>-fips_linux_amd64.tar.gz"
+        "https://greymatter.jfrog.io/artifactory/generic/greymatter-control-api/greymatter-control-api_<VERSION>-fips_linux_amd64.tar.gz"
+        "https://greymatter.jfrog.io/artifactory/generic/greymatter-dashboard/greymatter-dashboard_<VERSION>_linux_amd64.tar.gz"
+        "https://greymatter.jfrog.io/artifactory/generic/greymatter-proxy/greymatter-proxy_<VERSION>-fips-ubuntu_linux_amd64.tar.gz"
+        "https://greymatter.jfrog.io/artifactory/generic/greymatter-core/greymatter-core_<VERSION>_none_none.tar.gz"
+        "https://greymatter.jfrog.io/artifactory/generic/greymatter-audits/greymatter-audits_<VERSION>_linux_amd64.tar.gz"
+)
+
+USERNAME=$1
+API_KEY=$2
+
+if [[ -z "$USERNAME" ]] || [[ -z "$API_KEY" ]]; then
+    echo "${BASH_SOURCE[0]} <username> <api_key>"
+    echo "To get an api key navigate to the following and generate your own key:"
+    echo "https://www.jfrog.com/confluence/display/JFROG/User+Profile"
+    echo "You will need a greymatter.io account."
+    exit 1
+fi
+
+
+# for artifact in "${artifacts[@]}"; do
+#     echo "downloading $artifact"
+#     curl -s -L -u $USERNAME:$API_KEY \
+#         $artifact \
+#         -o $( echo $artifact | cut -d/ -f7 )
+# done

--- a/scripts/promotion
+++ b/scripts/promotion
@@ -1,0 +1,187 @@
+#!/bin/bash
+
+#TODO: add greymatter-core to this somehow
+
+# attempt to promote each image (indiscriminate if it was changed or not)
+
+# Promote will parse the path that is presented to it then 
+# will promote the oci and generic artifacts associated with it
+# THIS RELIES ON THE NAMING CONVENTION BEING FOLLOWED
+# input must look like 'release-oci/greymatter-audits/1.1.4-ubi8.6-2022-11-09'
+parse_and_promote(){
+    input=${1}
+
+    repo=$(echo ${input} | awk -F/ '{print $1}')
+    component=$(echo ${input} | awk -F/ '{print $2}')
+    image_tag=$(echo ${input} | awk -F/ '{print $3}')
+    version=$(echo ${image_tag} | awk -F- '{print $1}')
+    addl=$(echo ${image_tag} | sed "s|${version}||g")
+
+    if [[ -n ${component} || -n ${version} ]]; then
+        promote_oci ${component} ${version} ${addl}
+        promote_generic ${component} ${version}
+    else
+        echo "Count not promote the image or binary.  promote() was unable to parse a component or version"
+        exit 2
+    fi
+
+
+    if [[ ${dry_run_arg} -eq "" ]]; then
+        echo "${component}:${version}" >> release-versions.yaml
+    fi
+
+}
+
+# coppies the template and subs in the newly defined versions
+# will only run if release-versions.yaml is present... this only happens when not running a dry run
+create_download_script(){
+    # assumes branch name of form 'release/v#.#.#-rc#'
+    # this is a system version
+    release_version=""
+    new_name=$(git rev-parse --abbrev-ref HEAD | awk -F/ '{print $2}')
+    if [[ ! -z ${new_name} ]]; then
+        release_version="-${new_name}"
+    fi
+
+    cp scripts/greymatter-download-template.sh "greymatter-download${release_version}.sh"
+    # uses the versions in the inputs.cue to drive the files in the download script
+    if [[ -f release-versions.yaml ]]; then
+
+        lines=$(cat release-versions.yaml)
+        # echo ${lines}
+        for l in ${lines[@]}; do
+            echo "$l"
+            component=$(echo $l | awk -F: '{print $1}')
+            version=$(echo $l | awk -F: '{print $2}')
+            sed -i "s|${component}_<VERSION>|${component}_${version}|g" "greymatter-download${release_version}.sh"
+        done
+    fi
+
+    if [[ -n ${BUILDKITE_TAG} ]];then
+        sed -i "s|greymatter-core_<VERSION>|greymatter-core_${BUILDKITE_TAG:1}|g" "greymatter-download${release_version}.sh"
+    fi
+}
+
+
+
+
+# validates the <component>/version-additional image exists in 
+# the src_oci registry and promotes it to dest_oci set as environment variables
+promote_oci(){
+    component=${1}
+    version=${2}
+    addl=${3}
+
+    src_path=${SRC_OCI}/${component}/${version}${addl}
+
+    echo "Validating the source image [${src_path}] exist"
+    (jf rt search "${src_path}/" --fail-no-op=true)
+    if [[ $? -eq 0 ]]; then
+        echo "Promoting [${src_path}] to ${DEST_OCI}"
+        jf rt cp ${src_path} ${DEST_OCI} ${dry_run_arg}
+    else
+        echo "Validation failed: Did not find any images in [${src_path}]"
+        exit 4
+    fi
+
+}
+
+# validates the <component>/version-additional image exists in the 
+# src_generic registry and promotes all of that version to dest_generic set as environment variables
+promote_generic(){
+    component=${1}
+    version=${2}
+
+    bins=$(jf rt search "${SRC_GENERIC}/${component}/${component}_${version}*" | jq -r '.[].path')
+    arr=($bins)
+    echo "Validating the source generic artifacts in [${src_path}] exist"
+    if [[ ${#arr[@]} -gt 0  ]]; then
+        for i in "${arr[@]}"; do
+            echo "Moving [${i}] to ${DEST_GENERIC}"
+            jf rt cp ${i} ${DEST_GENERIC}/ ${dry_run_arg}
+        done
+    else
+        echo "Validation failed: Did not find any artifacts in [${src_path}]"
+        exit 4
+    fi
+}
+
+# imputs of location of images in cue eval of inputs.cue
+# finds all images that are in greymatter.jfrog.io and will push them to promotion
+get_and_promote_from_cue_inputs(){
+    images_block=$(cue eval inputs.cue --out json | jq ".${1}")
+
+    for i in $(echo ${images_block} | jq -r '. | keys[]'); do
+        echo ${i}
+        image_path=$(echo ${images_block} | jq '.' | jq -r --arg comp ${i} '.[$comp]' | sed "s|:|/|g" )
+        if [[ $(echo ${image_path} | awk -F/ '{print $1}') == "greymatter.jfrog.io" ]]; then
+            echo "Will promote greymatter internal image [${image_path}]"
+            jf_image_path=$(echo ${image_path} | sed "s|greymatter.jfrog.io/||g")
+            if [[ ${jf_image_path} != null ]]; then
+                echo "found image path [${jf_image_path}] for component [${i}] in inputs.cue"
+                parse_and_promote ${jf_image_path}
+            else
+                echo "did not find an image path for component [${i}] in inputs.cue under .defaults.image"
+                exit 4
+            fi
+        else
+            echo "will not promote non greymatter internal images [${image_path}]"
+        fi
+    done
+
+}
+
+# ######### Main ########
+
+
+dry_run_arg="--dry-run"
+if [[ ${1} == "--yes" ]]; then
+    dry_run_arg=""
+else
+    echo "Running in --dry-run mode"
+    echo "****************************************"
+    echo "if you would like to run this for real "
+    echo "add the --yes argument"
+    echo "ex:"
+    echo "./scripts/promotion --yes"
+    echo "****************************************"
+fi
+
+export SRC_GENERIC=${SRC_GENERIC_CI:-"dev-generic"}
+export DEST_GENERIC=${DEST_GENERIC_CI:-"generic"}
+export SRC_OCI=${SRC_OCI_CI:-"release-oci"}
+export DEST_OCI=${DEST_OCI_CI:-"oci"}
+
+echo "Promoting Generic Artifacts from ${SRC_GENERIC} to ${DEST_GENERIC}"
+echo "Promoting OCI Artifacts from ${SRC_OCI} to ${DEST_OCI}"
+
+
+get_and_promote_from_cue_inputs "mesh.spec.images"
+get_and_promote_from_cue_inputs "defaults.images"
+
+create_download_script
+cat inputs.cue | sed "s|greymatter.jfrog.io/$SRC_OCI|greymatter.jfrog.io/$DEST_OCI|g" > inputs-output.cue
+
+# if this is a tag then promote it and change the name to release
+if [[ -n ${BUILDKITE_TAG} ]]; then
+    # pull from staging
+    jf rt download ${SRC_GENERIC}/greymatter-core/greymatter-core_latest_none_none.tar.gz .
+    # g unzip
+    gzip -d greymatter-core_latest_none_none.tar.gz
+    # tar update file with new inputs.cue w/ updated input.cue
+    tar -u greymatter-core_latest_none_none.tar inputs.cue 
+    # gzip it
+    gzip greymatter-core_latest_none_none.tar
+    # push to release
+    jF rt upload greymatter-core_latest_none_none.tar ${DEST_GENERIC}/greymatter-core/greymatter-core_${BUILDKITE_TAG:1}_none_none.tar.gz 
+else 
+    # standart promotion; when no tag move to staging
+    promote_generic "greymatter-core" "latest"
+fi
+
+echo "Completed promotion Pipeline"
+
+unset SRC_GENERIC
+unset DEST_GENERIC
+unset SRC_OCI
+unset DEST_OCI


### PR DESCRIPTION
[sc-31811]

This PR automates a lot of the release process for us.

> This follows our new paradigm that the inputs.cue is the source of truth and not the `release.toml`

- devs can continue to work with their release-oci images in inputs.cue
- when a pr is opened to main the full main pipeline will run
    -  dryrun attempt to move oci and generic artifacts to staging
    - if that succeeds then it will run again and move that stuff to staging 
    - generate an inputs-staging.cue w/ the staging images already changed out
- on a tag
    - ask user to unblock it if there they have run a smoke test on the staging artifacts
    - check to make sure the changelog has changed between the last tag and the new tag
    - promote artifacts to public facing release repos
    - generate a `greymatter-download*.sh` script (this is not currently pushed up to the generic release repo) 

> obviously this has not been tested all the way through.  Its just a base line for the release process but based on the pipelines i've run it should cut our release time down from a couple hours to a couple min.

Hopefully this will result in faster feedback on release candidates!