### PR TITLE
conditionally set secure oidc token cookies

### DIFF
--- a/gm/intermediates.cue
+++ b/gm/intermediates.cue
@@ -726,7 +726,7 @@ _oidc_authentication_defaults: {
 		if location == "cookie" {
 			cookieOptions: {
 				httpOnly: *true | _
-				secure:   *false | _
+				secure:   bool | *defaults.edge.enable_tls
 				maxAge:   *"6h" | _
 				domain:   *"" | _
 				path:     *"/" | _
@@ -740,7 +740,7 @@ _oidc_authentication_defaults: {
 		if location == "cookie" {
 			cookieOptions: {
 				httpOnly: *true | _
-				secure:   *false | _
+				secure:   bool | *defaults.edge.enable_tls
 				maxAge:   *"6h" | _
 				domain:   *"" | _
 				path:     *"/" | _


### PR DESCRIPTION
[Security best practice](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#restrict_access_to_cookies) states that we should be using secure cookies when TLS is enabled. 