### PR TITLE
Add script to re order manifest outputs from cue evals. Follows resou…

### DIFF
--- a/.buildkite/branch.yaml
+++ b/.buildkite/branch.yaml
@@ -46,19 +46,41 @@ steps:
       - build
       - test
     commands:
+      - mkdir generated-manifests-cue-output/
+      - mkdir transform-manifest/
       - mkdir generated-manifests/
-      - cue eval -c ./k8s/outputs -e operator_manifests_yaml --out=text > generated-manifests/operator.yaml
-      - sed -i 's/git@github.com:greymatter-io\/greymatter-core.git/git@github.com:<your-org>\/greymatter-core.git/g' generated-manifests/operator.yaml 
+
+      - cue eval -c ./k8s/outputs -e operator_manifests_yaml --out=text > generated-manifests-cue-output/operator.yaml
+      - sed -i 's/git@github.com:greymatter-io\/greymatter-core.git/git@github.com:<your-org>\/greymatter-core.git/g' generated-manifests-cue-output/operator.yaml
+      - mv generated-manifests-cue-output/operator.yaml transform-manifest/manifest.yaml
+      - ./scripts/reorder-manifest.py
+      - if [[ $(cat transform-manifest/manifest-reorder.yaml | tail -1) == "---" ]]; then echo "Not All k8s resources were added to manifest during reorder" && exit 2; fi
+      - mv transform-manifest/manifest-reorder.yaml generated-manifests/operator.yaml
       
-      - cue eval -c ./k8s/outputs -e operator_manifests_yaml --out=text -t spire=true > generated-manifests/operator-spire.yaml
-      - sed -i 's/git@github.com:greymatter-io\/greymatter-core.git/git@github.com:<your-org>\/greymatter-core.git/g' generated-manifests/operator-spire.yaml
-      
-      - cue eval -c ./k8s/outputs -e operator_manifests_yaml --out=text -t openshift=true > generated-manifests/operator-openshift.yaml
-      - sed -i 's/git@github.com:greymatter-io\/greymatter-core.git/git@github.com:<your-org>\/greymatter-core.git/g' generated-manifests/operator-openshift.yaml
-      
-      - cue eval -c ./k8s/outputs -e operator_manifests_yaml --out=text -t openshift=true -t spire=true > generated-manifests/operator-openshift-spire.yaml
-      - sed -i 's/git@github.com:greymatter-io\/greymatter-core.git/git@github.com:<your-org>\/greymatter-core.git/g' generated-manifests/operator-openshift-spire.yaml
-      
+      - cue eval -c ./k8s/outputs -e operator_manifests_yaml --out=text -t spire=true > generated-manifests-cue-output/operator-spire.yaml
+      - sed -i 's/git@github.com:greymatter-io\/greymatter-core.git/git@github.com:<your-org>\/greymatter-core.git/g' generated-manifests-cue-output/operator-spire.yaml
+      - mv generated-manifests-cue-output/operator-spire.yaml transform-manifest/manifest.yaml
+      - ./scripts/reorder-manifest.py
+      - if [[ $(cat transform-manifest/manifest-reorder.yaml | tail -1) == "---" ]]; then echo "Not All k8s resources were added to manifest during reorder" && exit 2; fi
+      - mv transform-manifest/manifest-reorder.yaml generated-manifests/operator-spire.yaml
+
+      - cue eval -c ./k8s/outputs -e operator_manifests_yaml --out=text -t openshift=true > generated-manifests-cue-output/operator-openshift.yaml
+      - sed -i 's/git@github.com:greymatter-io\/greymatter-core.git/git@github.com:<your-org>\/greymatter-core.git/g' generated-manifests-cue-output/operator-openshift.yaml
+      - mv generated-manifests-cue-output/operator-openshift.yaml transform-manifest/manifest.yaml
+      - ./scripts/reorder-manifest.py
+      - if [[ $(cat transform-manifest/manifest-reorder.yaml | tail -1) == "---" ]]; then echo "Not All k8s resources were added to manifest during reorder" && exit 2; fi
+      - mv transform-manifest/manifest-reorder.yaml generated-manifests/operator-openshift.yaml
+
+
+      - cue eval -c ./k8s/outputs -e operator_manifests_yaml --out=text -t openshift=true -t spire=true > generated-manifests-cue-output/operator-openshift-spire.yaml
+      - sed -i 's/git@github.com:greymatter-io\/greymatter-core.git/git@github.com:<your-org>\/greymatter-core.git/g' generated-manifests-cue-output/operator-openshift-spire.yaml
+      - mv generated-manifests-cue-output/operator-openshift-spire.yaml transform-manifest/manifest.yaml
+      - ./scripts/reorder-manifest.py
+      - if [[ $(cat transform-manifest/manifest-reorder.yaml | tail -1) == "---" ]]; then echo "Not All k8s resources were added to manifest during reorder" && exit 2; fi
+      - mv transform-manifest/manifest-reorder.yaml generated-manifests/operator-openshift-spire.yaml
+
+      - rm -r generated-manifests-cue-output/
+      - rm -r transform-manifest/
       - buildkite-agent artifact upload "generated-manifests/*"
 
   - label: "Create Tarball and push to staging"

--- a/scripts/reorder-manifest.py
+++ b/scripts/reorder-manifest.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import yaml
+import argparse
+import os
+
+# resource_order to apply
+# most from helm's implementation
+# SecurityContextConstraints best guess location
+resource_order=("Namespace", "NetworkPolicy", "ResourceQuota", "LimitRange", "PodSecurityPolicy", "PodDisruptionBudget", "ServiceAccount", "Secret", "SecretList", "ConfigMap", "StorageClass", "PersistentVolume", "PersistentVolumeClaim", "CustomResourceDefinition","SecurityContextConstraints", "ClusterRole", "ClusterRoleList", "ClusterRoleBinding", "ClusterRoleBindingList", "Role", "RoleList", "RoleBinding", "RoleBindingList", "Service", "DaemonSet", "Pod", "ReplicationController", "ReplicaSet", "Deployment", "HorizontalPodAutoscaler", "StatefulSet", "Job", "CronJob", "IngressClass", "Ingress", "APIService")
+
+# list of dicts
+objects=[]
+with open("transform-manifest/manifest.yaml", "r") as file:
+    try:
+        print("---- Loading yaml ----")
+        resources = yaml.safe_load_all(file)
+        type(resources)
+
+        for i in resources:
+            print(i['kind'])
+            objects.append(i)
+
+    except yaml.YAMLError as exc:
+        print(exc)
+    print("---- Done Load ----")
+
+
+processed_objects=0
+for r in resource_order:
+    print(f'> Resource: {r}')
+    # print("")
+
+    for i in objects:
+        
+        kind=i['kind']
+        name=i['metadata']['name']
+        
+        # print(f'Looking at kind: [{kind}] , name: [{name}]')
+        if kind == r:
+            print("    " + name)
+
+            with open("transform-manifest/manifest-reorder.yaml", 'a') as file:
+                yaml.safe_dump(i,file)
+                if processed_objects != len(objects)-1:
+                    file.write("---\n")
+            
+                processed_objects = processed_objects + 1
+    
+print("")
+


### PR DESCRIPTION
…rces install order from helm

[sc-29390]

> This PR will re order manifests for packaging into the release tarball.  This happens after cue eval since the way we organize our cue does not readily lead to proper ordering.  The Generate manifest pipeline step will fail if the resources being added is not in the order_list.

Example order from `operator-openshift-spire.yaml`
<img width="343" alt="image" src="https://user-images.githubusercontent.com/21246992/208983961-754eead7-ba26-4105-9e02-b97fcbe16383.png">

The order resources are being set up are similar to https://github.com/helm/helm/blob/9ad53aac42165a5fadc6c87be0dea6b115f93090/pkg/tiller/kind_sorter.go#L29

I added `SecurityContextConstraints` to that order using my best judgment based on looking at what references to it and what uses it.

