### PR TITLE
Update cue for gm and k8s to allow mtls on the edge; update tests to …

### DIFF
--- a/global_intermediates.cue
+++ b/global_intermediates.cue
@@ -8,13 +8,13 @@ package greymatter
 //     tls edge + spire internal
 #SecuritySpecv1:{
     edge:{
-        type: "plaintext" | "tls"
+        type: "plaintext" | "tls" | "mtls"
         secret_name: string
     }
 
     internal:{
         type: [
-            if (edge.type == "tls"){ "plaintext" | "spire" | "manual-certs"}
+            if (edge.type == "tls" || edge.type == "mtls") { "plaintext" | "spire" | "manual-certs"}
             if (edge.type =="plaintext") { "plaintext" | "spire"}
         ][0]
         spire:{
@@ -36,7 +36,8 @@ package greymatter
 _security_spec: #SecuritySpecv1 &{
     edge:{
         type: [
-            if defaults.edge.enable_tls == true {"tls"}
+            if (defaults.edge.enable_tls == true && defaults.edge.require_client_certs == false){"tls"}
+            if (defaults.edge.enable_tls == true && defaults.edge.require_client_certs == true){"mtls"}
             if defaults.edge.enable_tls == false {"plaintext"}
         ][0]
         secret_name: defaults.edge.secret_name

--- a/gm/outputs/edge.cue
+++ b/gm/outputs/edge.cue
@@ -18,12 +18,16 @@ edge_config: [
 	#domain & {
 		domain_key:        defaults.edge.key
 		_force_https:[
-			if _security_spec.edge.type == "tls" {true}
+			if (_security_spec.edge.type == "tls" || _security_spec.edge.type == "mtls") {true}
 			if _security_spec.edge.type == "plaintext" {false}
 		][0]
 		_trust_file:       "/etc/proxy/tls/edge/ca.crt"
 		_certificate_path: "/etc/proxy/tls/edge/server.crt"
 		_key_path:         "/etc/proxy/tls/edge/server.key"
+		_require_client_certs: [
+			if _security_spec.edge.type == "mtls" {true}
+			if (_security_spec.edge.type == "tls" || _security_spec.edge.type == "plaintext") {false}
+		][0]
 	},
 	#listener & {
 		listener_key:                defaults.edge.key
@@ -35,7 +39,7 @@ edge_config: [
 		_enable_ext_authz:           false
 		_oidc_endpoint:              defaults.edge.oidc.endpoint
 		_edge_protocol:[
-			if _security_spec.edge.type == "tls" {"https"}
+			if (_security_spec.edge.type == "tls" || _security_spec.edge.type == "mtls") {"https"}
 			if _security_spec.edge.type == "plaintext" {"http"}
 		][0]
 		_oidc_service_url:   "\(_edge_protocol)://\(defaults.edge.oidc.edge_domain):\(defaults.ports.edge_ingress)"

--- a/inputs.cue
+++ b/inputs.cue
@@ -166,6 +166,7 @@ defaults: {
 		// then you will need to add those certs to another secret and specity that
 		// below at defaults.core_internal_tls_certs.cert_secret.
 		enable_tls:  bool | *false @tag(edge_enable_tls,type=bool)
+		require_client_certs: bool | *false @tag(edge_require_client_certs, type=bool)
 		secret_name: "gm-edge-ingress-certs"
 		oidc: {
 			// upstream_host is the FQDN of your OIDC service.

--- a/k8s/intermediates.cue
+++ b/k8s/intermediates.cue
@@ -55,7 +55,7 @@ import (
 			mountPath: defaults.spire.socket_mount_path
 		}]
 	}
-	if _security_spec.edge.type == "tls" && !(_security_spec.internal.type == "spire" && _security_spec.internal.spire.host_mount_socket) {
+	if (_security_spec.edge.type == "tls" || _security_spec.edge.type == "mtls") && !(_security_spec.internal.type == "spire" && _security_spec.internal.spire.host_mount_socket) {
 		[{
 			name: "internal-tls-certs"
 			mountPath: "/etc/proxy/tls/sidecar/"
@@ -72,7 +72,7 @@ import (
 			hostPath: {path: defaults.spire.socket_mount_path, type: "DirectoryOrCreate"}
 		}]
 	}
-	if _security_spec.edge.type == "tls" && !(_security_spec.internal.type == "spire" && _security_spec.internal.spire.host_mount_socket) {
+	if (_security_spec.edge.type == "tls" || _security_spec.edge.type == "mtls") && !(_security_spec.internal.type == "spire" && _security_spec.internal.spire.host_mount_socket) {
 		[{
 			name: "internal-tls-certs"
 			secret: {defaultMode: 420, secretName: defaults.edge.secret_name}

--- a/k8s/outputs/edge.cue
+++ b/k8s/outputs/edge.cue
@@ -29,7 +29,7 @@ edge: [
 						#sidecar_container_block & {
 							_Name: defaults.edge.key
 							_volume_mounts: [
-								if _security_spec.edge.type == "tls" {
+								if (_security_spec.edge.type == "tls" || _security_spec.edge.type == "mtls") {
 									{
 										name:      "tls-certs"
 										mountPath: "/etc/proxy/tls/edge"
@@ -43,7 +43,7 @@ edge: [
 						},
 					]
 					volumes: #sidecar_volumes + [
-							if _security_spec.edge.type == "tls" {
+							if (_security_spec.edge.type == "tls" || _security_spec.edge.type == "mtls") {
 							{
 								name: "tls-certs"
 								secret: {

--- a/k8s/outputs/keycloak_realm.cue
+++ b/k8s/outputs/keycloak_realm.cue
@@ -4,7 +4,7 @@
 package greymatter
 
 _sslRequired: *"none" | string
-if _security_spec.edge.type == "tls" {_sslRequired: "external"}
+if (_security_spec.edge.type == "tls" || _security_spec.edge.type == "mtls") {_sslRequired: "external"}
 
 realm_data: {
 	"id":                                  "fd023dcc-aaec-4001-aafe-56988e38eaea"


### PR DESCRIPTION
…accommodate


First part to [sc-32689]

This PR adds mtls on the edge.  To set up mtls on the edge you will need certs for the edge like normal but then in inputs.cue you will need to set both the following to true:

```
edge:
  enable_tls:  bool | *false @tag(edge_enable_tls,type=bool)
  require_client_certs: bool | *false @tag(edge_require_client_certs, type=bool)
```

If for some reason someone accidentally sets edge.require_client_certs to true but does not enable_tls on the edge then it will fall back to no tls (no reason to require client certs if you yourself dont need certs lol)

for local unit testing you can run `pytest scripts/gm_test_functions.py --no-header -v`

If you are going to be setting this up you'll need to transform PEM format certs to p12 for your browser.  To do this run `openssl pkcs12 -export -out myf.p12 -in <my pem cert>.crt -inkey <my pem key>.key` and load it into your browser.
