### PR TITLE
Enable mtls internal; add tests for it

### DIFF
--- a/global_intermediates.cue
+++ b/global_intermediates.cue
@@ -14,7 +14,7 @@ package greymatter
 
     internal:{
         type: [
-            if (edge.type == "tls" || edge.type == "mtls") { "plaintext" | "spire" | "manual-certs"}
+            if (edge.type == "tls" || edge.type == "mtls") { "plaintext" | "spire" | "manual-tls" | "manual-mtls"}
             if (edge.type =="plaintext") { "plaintext" | "spire"}
         ][0]
         spire:{
@@ -36,21 +36,22 @@ package greymatter
 _security_spec: #SecuritySpecv1 &{
     edge:{
         type: [
+            if defaults.edge.enable_tls == false {"plaintext"}
             if (defaults.edge.enable_tls == true && defaults.edge.require_client_certs == false){"tls"}
             if (defaults.edge.enable_tls == true && defaults.edge.require_client_certs == true){"mtls"}
-            if defaults.edge.enable_tls == false {"plaintext"}
         ][0]
         secret_name: defaults.edge.secret_name
     }
     internal:{
         type: [
             if config.spire == true {"spire"}
-            if defaults.core_internal_tls_certs.enable == true {"manual-certs"}
+            if (defaults.core_internal_tls_certs.enable == true && defaults.core_internal_tls_certs.require_client_certs == false) {"manual-tls"}
+            if (defaults.core_internal_tls_certs.enable == true && defaults.core_internal_tls_certs.require_client_certs == true) {"manual-mtls"}
             "plaintext"
         ][0]
         spire: defaults.spire
         manual:{
             secret_name: defaults.core_internal_tls_certs.cert_secret
-        } 
+        }
     }
 }

--- a/gm/outputs/edge.cue
+++ b/gm/outputs/edge.cue
@@ -17,17 +17,9 @@ edge_config: [
 	// This domain is special because it uses edge certs instead of sidecar certs.  This secures outside -> in traffic
 	#domain & {
 		domain_key:        defaults.edge.key
-		_force_https:[
-			if (_security_spec.edge.type == "tls" || _security_spec.edge.type == "mtls") {true}
-			if _security_spec.edge.type == "plaintext" {false}
-		][0]
 		_trust_file:       "/etc/proxy/tls/edge/ca.crt"
 		_certificate_path: "/etc/proxy/tls/edge/server.crt"
 		_key_path:         "/etc/proxy/tls/edge/server.key"
-		_require_client_certs: [
-			if _security_spec.edge.type == "mtls" {true}
-			if (_security_spec.edge.type == "tls" || _security_spec.edge.type == "plaintext") {false}
-		][0]
 	},
 	#listener & {
 		listener_key:                defaults.edge.key

--- a/inputs.cue
+++ b/inputs.cue
@@ -160,12 +160,13 @@ defaults: {
 		// rely on this value, such as the audit app's queries to Elasticsearch. 
 		// The value should not need to be changed.
 		key: "edge"
-		// edge.enable_tls toggles internal mtls connections between greymatter core components
-		// by default the internal and external secrets are the same however if you want to
-		// have different certs for the ingress and internal connections (this is the case for prod)
-		// then you will need to add those certs to another secret and specity that
-		// below at defaults.core_internal_tls_certs.cert_secret.
+		// To enable TLS on the edge set edge.enable_tls to true.
+		// This config also toggles enables internal TLS across sidecars.  That behavior can be changed 
+		// by setting the toggle defaults.internal.core_internal_tls_certs.enable to true.
 		enable_tls:  bool | *false @tag(edge_enable_tls,type=bool)
+		// To enable mTLS on the edge, edge.require_client_certs should be set to true in addition to edge.enable_tls.
+		// This config also toggles enables internal TLS across sidecars.  That behavior can be changed
+		// by setting the toggle defaults.internal.core_internal_tls_certs.require_client_certs to true.
 		require_client_certs: bool | *false @tag(edge_require_client_certs, type=bool)
 		secret_name: "gm-edge-ingress-certs"
 		oidc: {
@@ -234,9 +235,14 @@ defaults: {
 	}
 
 	core_internal_tls_certs: {
+		// Enables internal TLS (requires defaults.edge.enable_tls == true)
 		enable: bool | *defaults.edge.enable_tls @tag(internal_enable_tls,type=bool)
-		// use npe cert for internal mtls
+		// Enables internal mTLS (requires: defaults.edge.enable_tls == true && defaults.core_internal_tls_certs.enable == true )
+		require_client_certs: bool | *defaults.edge.require_client_certs @tag(internal_require_client_certs, type=bool)
 		// Name of kubernetes secret to be mounted
+		// By default the same secret for external TLS/mTLS will be used for internal TLS/mTLS.
+		// Different certs can be used by specifying a different
+		// secret name in defaults.core_internal_tls_certs.cert_secret.
 		cert_secret: string | *defaults.edge.secret_name
 	}
 


### PR DESCRIPTION
Enables mtls for internal services (manual-mtls) and add tests that will ensure these stay in a good state.


[sc-32689]

Configuration Options:

| edge      | internal  | defaults.edge.enable_tls | defaults.edge.require_client_certs | defaults.core_internal_tls_certs.enable | defaults.core_internal_tls_certs.require_client_certs | configs.spire |
| --------- | --------- | ------------------------ | ---------------------------------- | --------------------------------------- | ----------------------------------------------------- | ------------- |
| plaintext | plaintext | false                    | false                              | false                                   | false                                                 | false         |
| plaintext | spire     | false                    | false                              | false                                   | false                                                 | true          |
| tls       | plaintext | true                     | false                              | false                                   | false                                                 | false         |
| tls       | tls       | true                     | false                              | true                                    | false                                                 | false         |
| tls       | mtls      | true                     | false                              | true                                    | true                                                  | false         |
| tls       | spire     | true                     | false                              | false                                   | false                                                 | true          |
| mtls      | plaintext | true                     | true                               | false                                   | false                                                 | false         |
| mtls      | tls       | true                     | true                               | true                                    | false                                                 | false         |
| mtls      | mtls      | true                     | true                               | true                                    | true                                                  | false         |
| mtls      | spire     | true                     | true                               | false                                   | false                                                 | true          |


> External prometheus tls, tls/mtls edge and keycloak, and observables -> elasticsearch have not been tested

> all tls and mtls tests require you to create your own secret