### PR TITLE
Update parse and promote script to ignore the operator image

### DIFF
--- a/scripts/promotion
+++ b/scripts/promotion
@@ -17,14 +17,16 @@ parse_and_promote(){
     version=$(echo ${image_tag} | awk -F- '{print $1}')
     addl=$(echo ${image_tag} | sed "s|${version}||g")
 
-    if [[ -n ${component} || -n ${version} ]]; then
-        promote_oci ${component} ${version} ${addl}
-        promote_generic ${component} ${version}
-    else
-        echo "Count not promote the image or binary.  promote() was unable to parse a component or version"
-        exit 2
+    if [[ $component != "greymatter-operator" ]]; then
+    
+        if [[ -n ${component} || -n ${version} ]]; then
+            promote_oci ${component} ${version} ${addl}
+            promote_generic ${component} ${version}
+        else
+            echo "Count not promote the image or binary.  promote() was unable to parse a component or version"
+            exit 2
+        fi
     fi
-
 
     if [[ ${dry_run_arg} -eq "" ]]; then
         echo "${component}:${version}" >> release-versions.yaml


### PR DESCRIPTION
This PR enables the promotion script to run through without failing due to an operator image not being present in dev-oci or ci-staging-oci.

This is because of the circular dependency in greymatter core and operator.  You need to cut greymatter-core before the operator can be cut.

Those two should be in the same repo.